### PR TITLE
KeyedSGLDataBlockDescriptor: addr, len + key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.ibm.jnvmf</groupId>
   <artifactId>jnvmf</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.1</version>
   <name>jnvmf</name>
   <description>A NVMe over Fabrics library for Java</description>
   <url>https://github.com/zrlio/jNVMf</url>

--- a/src/main/java/com/ibm/jnvmf/KeyedSglDataBlockDescriptor.java
+++ b/src/main/java/com/ibm/jnvmf/KeyedSglDataBlockDescriptor.java
@@ -59,7 +59,7 @@ public class KeyedSglDataBlockDescriptor extends ScatterGatherListDescriptor {
     setIdentifier(Type.getInstance().KEYED_SGL_DATABLOCK, subType);
   }
 
-  void setAddress(long address) {
+  public void setAddress(long address) {
     setSubType(SubType.getInstance().ADDRESS);
     getBuffer().putLong(ADDRESS_OFFSET, address);
   }
@@ -68,7 +68,7 @@ public class KeyedSglDataBlockDescriptor extends ScatterGatherListDescriptor {
     setSubType(SubType.getInstance().INVALIDATE_KEY);
   }
 
-  void setLength(int length) {
+  public void setLength(int length) {
     if ((length & 0xFFFFFF) != length) {
       throw new IllegalArgumentException("Invalid length. Max 3 bytes.");
     }
@@ -78,7 +78,7 @@ public class KeyedSglDataBlockDescriptor extends ScatterGatherListDescriptor {
     getBuffer().put(currentOffset + Short.BYTES, (byte) length);
   }
 
-  void setKey(int key) {
+  public void setKey(int key) {
     getBuffer().putInt(KEY_OFFSET, key);
   }
 

--- a/src/main/java/com/ibm/jnvmf/NvmIoCommandSqe.java
+++ b/src/main/java/com/ibm/jnvmf/NvmIoCommandSqe.java
@@ -44,7 +44,7 @@ public abstract class NvmIoCommandSqe extends NvmSubmissionQueueEntry {
 
   //TODO metadata
 
-  KeyedSglDataBlockDescriptor getKeyedSglDataBlockDescriptor() {
+  public KeyedSglDataBlockDescriptor getKeyedSglDataBlockDescriptor() {
     return keyedSglDataBlockDescriptor;
   }
 


### PR DESCRIPTION
Allow to set address, length and key individually besides
passing a KeyedNativeBuffer.

Signed-off-by: Jonas Pfefferle <jpf@zurich.ibm.com>